### PR TITLE
all messages now contain statistics

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,18 @@
 <template>
-  <div className="w-screen h-screen flex overflow-hidden">
-    <ChatGPT
-      :query="this.query"
-      v-for="chat in gptChats"
-      :chatParams="chat"
-      @chat-closed="handleChatClosed"
-    />
-    <!-- Visual divider -->
-    <!-- <div class="w-2 h-full bg-black" /> -->
-    <Gemini
-      :query="this.query"
-      v-for="chat in geminiChats"
-      :chatParams="chat"
-      @chat-closed="handleChatClosed"
-    />
+  <div class="w-screen h-screen flex overflow-hidden">
+    <template v-for="(chat, index) in allChats" :key="chat.id">
+      <component
+        :is="chat.type === 'gemini' ? 'Gemini' : 'ChatGPT'"
+        :query="query"
+        :chatParams="chat"
+        @chat-closed="handleChatClosed"
+      />
+      <!-- Visual divider -->
+      <div
+        v-if="index < allChats.length - 1"
+        class="w-1.5 h-full bg-black"
+      />
+    </template>
 
     <NewChat @addChat="addChat" :totalChats="totalChats" />
 
@@ -98,6 +97,12 @@ export default {
     },
   },
 
+  computed: {
+    allChats() {
+      return [...this.geminiChats, ...this.gptChats];
+    },
+  },
+
   data() {
     return {
       commandBarActive: false,
@@ -110,4 +115,6 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+/* Add any specific styles here if needed */
+</style>

--- a/src/components/ChatSettings.vue
+++ b/src/components/ChatSettings.vue
@@ -9,19 +9,33 @@
     @click="handleClick($event)"
   >
     <div
-      class="flex flex-col mx-4 w-full max-w-2xl bg-[#0D0D0D] p-4 rounded-xl border border-[#404040] shadow-lg"
+      class="flex flex-col gap-4 mx-4 w-full max-w-2xl bg-[#0D0D0D] p-4 rounded-xl border border-[#404040] shadow-lg"
     >
+      <div class="flex w-full justify-between pb-2">
+        <h1 class="text-xl text-[#DFDD00]">Chat Settings</h1>
+        <CircleX
+          class="cursor-pointer transition-all duration-150 ease-in-out hover:stroke-red-500"
+          @click="toggleCommandBar"
+          size="20"
+        />
+      </div>
       <div class="flex justify-between text-[#A2A2A2]">
         Auto send mic input
         <Toggle @toggled="autoSend" />
       </div>
 
-      <div class="w-full flex justify-center">
+      <!-- <CommandBarListInput
+        text="Username"
+        type="text"
+        keyName="username"
+        default="You"
+      /> -->
+
+      <div class="w-full flex justify-center" @click="closeChat">
         <div
-          class="flex items-center border p-1 px-4 gap-2 rounded-full border-red-500 hover:bg-red-500 transition-all duration-300 ease-in-out cursor-pointer"
-          @click="closeChat"
+          class="transition-all duration-300 ease-in-out flex items-center gap-2 bg-red-400 p-1 rounded cursor-pointer hover:bg-red-500 p-2 mt-4 justify-center"
         >
-          Close Chat <X size="18" />
+          Close Chat <LogOut size="20"/>
         </div>
       </div>
     </div>
@@ -29,11 +43,12 @@
 </template>
 
 <script setup>
-import { X } from "lucide-vue-next";
+import { CircleX, LogOut } from "lucide-vue-next";
 </script>
 
 <script>
 import Toggle from "./Toggle.vue";
+import CommandBarListInput from "./CommandBarListInput.vue";
 export default {
   name: "ChatSettings",
   props: {
@@ -42,6 +57,7 @@ export default {
     chatParams: Object,
   },
   components: {
+    CommandBarListInput,
     Toggle,
   },
   methods: {

--- a/src/components/CommandBar.vue
+++ b/src/components/CommandBar.vue
@@ -1,83 +1,110 @@
 <template>
   <div
-    class="fixed z-[9999] w-screen bg-[#000000AB] text-white h-screen flex items-start justify-center transition-opacity duration-300 ease-in-out pt-64"
+    class="fixed z-[9999] w-screen backdrop-brightness-[0.20] text-white h-screen flex flex-col items-center justify-center transition-opacity duration-300 ease-in-out"
     :class="
       active
-        ? 'opacity-100 backdrop-blur-sm'
+        ? 'opacity-100 backdrop-blur'
         : 'opacity-0 pointer-events-none backdrop-blur-0'
     "
     @click="handleClick($event)"
   >
-    <div
-      class="flex flex-col mx-4 w-full max-w-2xl bg-[#0D0D0D] p-4 rounded-xl border border-[#404040] shadow-lg"
-    >
+    <div class="flex flex-col gap-6 w-full mx-4 max-w-2xl">
       <!-- Search Bar -->
-      <form
-        class="flex w-full gap-2 bg-[#060606FF] p-2 rounded-md mb-4"
-        @submit="submitSearchTerm"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="white"
-          class="w-6 h-6"
+      <div class="flex items-center">
+        <div
+          class="flex items-center cursor-pointer bg-[#060606FF] rounded-full border border-[#282828] overflow-hidden"
+          :class="
+            settingsOpen ? 'w-0 opacity-0 pointer-events-none' : 'p-2 mr-2'
+          "
+          @click="toggleSettings"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          <Settings2
+            size="20"
+            class="transition-all duration-300 ease-in-out opacity-50 hover:opacity-100"
+            :class="settingsOpen && '-translate-x-52'"
           />
-        </svg>
-        <input
-          type="text"
-          class="bg-transparent outline-none border-none text-white w-full"
-          autocomplete="off"
-          v-model="search"
-          ref="inputToFocus"
-        />
-      </form>
+        </div>
+        <form
+          class="flex flex-1 gap-2 bg-[#060606FF] p-2 px-3 rounded-full border border-[#282828]"
+          @submit="submitSearchTerm"
+        >
+          <input
+            type="text"
+            class="bg-transparent outline-none border-none text-white w-full"
+            autocomplete="off"
+            v-model="search"
+            ref="inputToFocus"
+            placeholder="Message all chats..."
+          />
+          <div
+            class="transition-all duration-300 ease-in-out opacity-50 hover:opacity-100 cursor-pointer"
+          >
+            <Search @click="submitSearchTerm" />
+          </div>
+        </form>
+      </div>
+      <div
+        class="flex flex-col bg-[#060606FF] p-4 rounded-xl border border-[#404040] shadow-lg transition-all duration-300 ease-in-out overflow-hidden"
+        :class="!settingsOpen ? 'max-h-0 opacity-0' : 'max-h-[30rem]'"
+      >
+        <div class="flex justify-between">
+          <h1 class="text-xl mb-6 text-[#DFDD00]">App Settings</h1>
+          <CircleX
+            class="cursor-pointer transition-all duration-150 ease-in-out hover:stroke-red-500"
+            @click="toggleSettings"
+            size="20"
+          />
+        </div>
+        <section class="mb-4">
+          <h3 class="pl-1 mb-4 text-[#e5e4e2]">User Settings</h3>
+          <CommandBarListInput
+            text="Username"
+            type="text"
+            keyName="username"
+            default="You"
+          />
+        </section>
+        <section class="mb-4">
+          <div class="pl-1 text-md mb-4 text-[#e5e4e2]">ChatGPT Settings</div>
+          <CommandBarListInput
+            text="API Key"
+            type="sensitive"
+            keyName="ChatGPTAPIKey"
+          />
+          <CommandBarListInput
+            text="Voice"
+            type="text"
+            keyName="ChatGPTVoice"
+          />
+        </section>
+        <section class="mb-4">
+          <div class="pl-1 text-md mb-4 text-[#e5e4e2]">Gemini Settings</div>
+          <CommandBarListInput
+            text="API Key"
+            type="sensitive"
+            keyName="GeminiAPIKey"
+          />
+          <CommandBarListInput text="Voice" type="text" keyName="GeminiVoice" />
+        </section>
 
-      <section class="mb-4">
-        <h3 class="text-[#FFFFFF7B] pl-1 mb-2">User Settings</h3>
-        <CommandBarListInput
-          text="Username"
-          type="text"
-          keyName="username"
-          default="You"
-        />
-      </section>
-      <section class="mb-4">
-        <div class="text-[#FFFFFF7B] pl-1 text-md mb-2">ChatGPT Settings</div>
-        <CommandBarListInput
-          text="API Key"
-          type="sensitive"
-          keyName="ChatGPTAPIKey"
-        />
-        <CommandBarListInput text="Voice" type="text" keyName="ChatGPTVoice" />
-      </section>
-      <section class="mb-4">
-        <div class="text-[#FFFFFF7B] pl-1 text-md mb-2">Gemini Settings</div>
-        <CommandBarListInput
-          text="API Key"
-          type="sensitive"
-          keyName="GeminiAPIKey"
-        />
-        <CommandBarListInput text="Voice" type="text" keyName="GeminiVoice" />
-      </section>
-
-      <section class="mb-4">
-        <div class="text-[#FFFFFF7B] pl-1 text-md mb-2">Eleven Labs</div>
-        <CommandBarListInput
-          text="API Key"
-          type="sensitive"
-          keyName="ElevenLabsAPIKey"
-        />
-      </section>
+        <section class="mb-4">
+          <div class="text-[#FFFFFF7B] pl-1 text-md mb-2 text-[#e5e4e2]">
+            Eleven Labs
+          </div>
+          <CommandBarListInput
+            text="API Key"
+            type="sensitive"
+            keyName="ElevenLabsAPIKey"
+          />
+        </section>
+      </div>
     </div>
   </div>
 </template>
+
+<script setup>
+import { Search, Settings2, CircleX } from "lucide-vue-next";
+</script>
 
 <script>
 import CommandBarListInput from "./CommandBarListInput.vue";
@@ -99,6 +126,10 @@ export default {
       if (event.target === event.currentTarget) {
         this.toggleCommandBar();
       }
+    },
+
+    toggleSettings() {
+      this.settingsOpen = !this.settingsOpen;
     },
 
     submitSearchTerm(e) {
@@ -123,6 +154,7 @@ export default {
   data() {
     return {
       search: "",
+      settingsOpen: false,
     };
   },
 };

--- a/src/components/CommandBarListInput.vue
+++ b/src/components/CommandBarListInput.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="flex items-center gap-4 pl-1 text-sm mb-4">
-    {{ text }}
-    <div
-      class="flex items-center h-8 pl-2 rounded flex-1"
-      :class="editing ? 'bg-[#060606FF]' : 'bg-[#151515FF]'"
+    <div class="w-20 text-[#FFFFFF7B]">{{ text }}</div>
+    <form
+      class="flex items-center h-8 pl-2 rounded flex-1 bg-[#151515FF]"
+      autocomplete="off"
+      @submit="toggleEditing"
     >
       <input
         :type="TypeLegend[type] || 'text'"
@@ -12,6 +13,7 @@
         @blur="toggleEditing"
         v-if="editing"
         ref="autoFocusInput"
+        autocomplete="new-password"
       />
       <div
         class="flex w-full items-center h-8 opacity-50 cursor-pointer"
@@ -20,7 +22,7 @@
       >
         {{ type === "sensitive" ? value.replace(/./g, "•") : value }}
       </div>
-    </div>
+    </form>
   </div>
 </template>
 
@@ -48,7 +50,10 @@ export default {
       }
     },
 
-    toggleEditing() {
+    toggleEditing(e) {
+      if (e) {
+        e.preventDefault();
+      }
       this.editing = !this.editing;
       if (this.editing) {
         this.$nextTick(() => {

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -1,0 +1,63 @@
+<template>
+    <div :class="loaderClass" :style="loaderStyle"></div>
+  </template>
+  
+  <script>
+  export default {
+    name: 'Loader',
+    props: {
+      size: {
+        type: Number,
+        default: 80,
+      },
+    },
+    computed: {
+      loaderClass() {
+        return 'loader';
+      },
+      loaderStyle() {
+        const size = `${this.size}px`;
+        const borderSize = `${this.size / 8}px`;
+        const radialSize = `${this.size / 4}px`;
+        const blurSize = this.size / 20; // Adjust blur size proportionally
+        return {
+          width: size,
+          height: size,
+          border: `${borderSize} solid #000`,
+          background: `
+            radial-gradient(farthest-side, #fff 98%, #0000) 50%/${radialSize} ${radialSize},
+            radial-gradient(farthest-side, #fff 98%, #0000) 50%/${radialSize} ${radialSize},
+            radial-gradient(farthest-side, #fff 98%, #0000) 50%/${radialSize} ${radialSize},
+            radial-gradient(farthest-side, #fff 98%, #0000) 50%/${radialSize} ${radialSize},
+            radial-gradient(farthest-side, #fff 98%, #0000) 50%/${radialSize} ${radialSize},
+            linear-gradient(#fff 0 0) 50%/100% ${borderSize},
+            linear-gradient(#fff 0 0) 50%/${borderSize} 100%, #000
+          `,
+          filter: `blur(${blurSize}px) contrast(10)`,
+        };
+      },
+    },
+  };
+  </script>
+  
+  <style scoped>
+  .loader {
+    aspect-ratio: 1;
+    box-sizing: border-box;
+    background-repeat: no-repeat;
+    animation: l13 0.8s infinite;
+  }
+  
+  @keyframes l13 {
+    100% {
+      background-position: 
+        50% -20px, 
+        -20px 50%, 
+        60px 50%, 
+        50% 60px, 
+        50%, 
+        50%, 
+        50%;
+    }
+  }
+  </style>

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -25,9 +25,8 @@
 </template>
 
 <script>
-import ChatGPTIcon from "./ChatGPTIcon.vue";
-import ProfileIcon from "./ProfileIcon.vue";
 import MessageIconArray from "./MessageIconArray.vue";
+import ProfileIcon from "./ProfileIcon.vue";
 import { marked } from "marked";
 
 marked.setOptions({
@@ -47,7 +46,6 @@ export default {
   },
 
   components: {
-    ChatGPTIcon,
     ProfileIcon,
     MessageIconArray,
   },
@@ -62,7 +60,7 @@ export default {
     return {
       senderLegend: {
         user: localStorage.getItem("username"),
-        'ai-chatgpt': "ChatGPT",
+        "ai-chatgpt": "ChatGPT",
         gemini: "Gemini",
       },
     };

--- a/src/components/MessageBox.vue
+++ b/src/components/MessageBox.vue
@@ -26,7 +26,7 @@
       v-model="message"
     />
 
-    <div class="mr-2">
+    <div class="transition-all duration-300 ease-in-out mr-2 opacity-50 hover:opacity-100">
       <CircleStop
         v-if="recording"
         class="cursor-pointer"
@@ -76,7 +76,6 @@ import { Mic, CircleStop } from "lucide-vue-next";
 
 <script>
 import Tooltip from "./Tooltip.vue";
-import { watch } from "vue";
 
 export default {
   name: "MessageBox",
@@ -170,7 +169,8 @@ export default {
         const textarea = this.$el.querySelector("textarea");
         textarea.style.height = "1.5rem"; // Reset height
         e.preventDefault();
-        this.submitEvent(this.message);
+        // this.submitEvent(this.message);
+        this.$emit("chat-submission", { message: this.message });
         this.message = "";
       }
     },

--- a/src/components/MessageIconAction.vue
+++ b/src/components/MessageIconAction.vue
@@ -1,25 +1,70 @@
 <template>
   <button
-    @click="action ? copy(message.message) : read()"
-    class="pr-1 opacity-50 hover:opacity-100 transition-all duration-200 ease-in-out"
+    @click="action ? copy(data.message) : read()"
+    class="transition-all duration-200 ease-in-out pr-1 opacity-50 hover:opacity-100 relative"
+    @mouseenter="showTooltip = true"
+    @mouseleave="showTooltip = false"
   >
-    <slot></slot>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="2.5"
+      stroke="currentColor"
+      class="w-4 h-4"
+      v-if="action === 'copy'"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+      />
+    </svg>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="2.5"
+      stroke="currentColor"
+      class="w-4 h-4"
+      v-if="action === 'read'"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z"
+      />
+    </svg>
+    <Info color="#fff" v-if="action === 'info'" size="18" />
+    <Tooltip :text="action" position="top" v-if="showTooltip" />
   </button>
 </template>
 
+<script setup>
+import { Info } from "lucide-vue-next";
+</script>
+
 <script>
-import read from "../utils/read.js";
 import copy from "../utils/copy.js";
+import read from "../utils/read.js";
+import Tooltip from "./Tooltip.vue";
 export default {
   name: "MessageIconAction",
+  components: {
+    Tooltip,
+  },
   props: {
     action: String,
-    message: Object,
+    data: Object,
+  },
+  mounted() {
+    console.log(this.action, this.data);
   },
   data() {
     return {
       read,
       copy,
+      showTooltip: false,
     };
   },
 };

--- a/src/components/MessageIconArray.vue
+++ b/src/components/MessageIconArray.vue
@@ -1,45 +1,18 @@
 <template>
   <!-- Icons Container -->
   <div
-    class="icons-container opacity-0 transition-all duration-300 ease-in-out mt-2"
+    class="flex gap-1 icons-container transition-all duration-300 ease-in-out mt-2"
   >
     <MessageIconAction
       action="read"
       v-if="message.sender !== 'user'"
-      :message="message"
+      :data="message"
       @click="handleAudioFetch(message.message)"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="2.5"
-        stroke="currentColor"
-        class="w-4 h-4"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z"
-        />
-      </svg>
-    </MessageIconAction>
-    <MessageIconAction action="copy" :message="message">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="2.5"
-        stroke="currentColor"
-        class="w-4 h-4"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
-        />
-      </svg>
-    </MessageIconAction>
+    />
+    <MessageIconAction action="copy" :data="message" />
+
+    <!-- Rename prop from message to data -->
+    <MessageIconAction action="info" :data="message" />
   </div>
 </template>
 

--- a/src/components/NewChat.vue
+++ b/src/components/NewChat.vue
@@ -1,8 +1,8 @@
 <template>
     <!-- Add new chat -->
-    <div class="h-screen w-screen fixed pointer-events-none">
+    <div class="h-screen w-screen fixed pointer-events-none z-[9999]">
       <div
-        class="absolute z-[9999] top-1/2 cursor-pointer add-new-chat sidebar-menu pointer-events-auto"
+        class="absolute z-[999] top-1/2 cursor-pointer add-new-chat sidebar-menu pointer-events-auto"
         :class="totalChats > 0 ? 'flex flex-col right-4' : 'flex items-center left-1/2'"
         @mouseenter="showBackgroundBlur"
         @mouseleave="hideBackgroundBlur"
@@ -15,7 +15,7 @@
             src="../assets/openai.webp"
             alt="Open AI"
             class="w-full h-full"
-            @click="addChat({ type: 'gpt', model: 'gpt-4-turbo' })"
+            @click="addChat({ type: 'gpt', model: 'gpt-4o' })"
           />
         </div>
         <CirclePlus
@@ -117,7 +117,7 @@
     background: rgba(0, 0, 0, 0.5);
     backdrop-filter: blur(10px);
     pointer-events: none;
-    transition: all 300ms ease-in-out;
+    transition: all 150ms ease-in-out;
     opacity: 0;
     width: 100vw;
     height: 100vh;

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute inset-x-1/2 flex flex-col items-center z-[999]"
+    class="absolute inset-x-1/2 flex flex-col items-center z-[9999]"
     :class="positionLegend[position]"
   >
     <!-- Carret -->

--- a/src/utils/newMessage.js
+++ b/src/utils/newMessage.js
@@ -1,0 +1,25 @@
+export default function newMessage({ start, end, message, sender, ...data }) {
+  let timeTaken;
+  let formattedTime;
+
+  console.log(message, sender, start, end)
+
+  // If the sender is not the user, calculate the time taken.
+  if (sender !== "user") {
+    timeTaken = end - start;
+    if (timeTaken > 1000) {
+      formattedTime = `${(timeTaken / 1000).toFixed(2)}s`;
+    } else {
+      formattedTime = `${timeTaken.toFixed(2)}ms`;
+    }
+  }
+  return {
+    id: Math.random(),
+    message: message,
+    sender: sender ?? "user",
+    timeTaken: timeTaken ?? "0ms",
+    messageLength: message.length,
+    formattedTime: formattedTime ?? "0ms",
+    ...data,
+  };
+}


### PR DESCRIPTION
# Stats update
* `ChatGPT` Windows can now be added.
* Reworked how messages are added into conversation arrays.
* Stats are now logged for every message sent.
* Reduced new chat backdrop animation to half its original length.
* Reworked close chat button for `ChatSettings`.
* Added a SVG for closing `ChatSettings` component.
* Updated file name referencing the message component from `ChatGPTMessages.vue` to a much more appropriate `Message.vue`
* Input fields in `CommandBar` now visually start uniformly.
* `CommandBar` styling rework for snappier feeling and a more modern look.
* Modified `ChatHeader` to accept and display the initial model dynamically. *(previously hardcoded to GPT-4)*
* `ChatGPT` now initializes with the `GPT-4o` model.
* Text fields in `CommandBar` no longer suggest autocompletes.